### PR TITLE
Don't error when parsing chiral SMILES

### DIFF
--- a/src/Brackets.jl
+++ b/src/Brackets.jl
@@ -66,7 +66,12 @@ function ParseBracket(S)
         elseif isspecialoperator(cursor)
             @warn("Invalid SMILES. Special operators(" * join(specialoperators, ",") * ") should not be contained in a bracket.")
         elseif isbondoperator(cursor)
-            @warn("Invalid SMILES. Bond operators(" * join(bondoperators, ",") * ") should not be contained in a bracket.")
+            if cursor == '@'
+                @warn("Chirality is not yet supported, ignoring @ operator", maxlog=1)
+                S = S[2:end]
+            else
+                @warn("Invalid SMILES. Bond operators(" * join(bondoperators, ",") * ") should not be contained in a bracket.")
+            end
         end
         #Ensure we don't get stuck in an infinite loop
         curlen = length( S )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,15 @@ end
     @test checkhydrogens[3] == 1
 end
 
+@testset "Chirality" begin
+    # Chirality is not fully supported, but we shouldn't error
+    G1, Data = OpenSMILES.ParseSMILES("N[C@](Br)(O)C")
+    @test OpenSMILES.EmpiricalFormula( Data ) == "BrC2H6NO"
+    G2, Data = OpenSMILES.ParseSMILES("N[C@@](Br)(C)O")
+    @test OpenSMILES.EmpiricalFormula( Data ) == "BrC2H6NO"
+    @test G1 == G2
+end
+
 @testset "ParseOpenSMILES Empirical Formulas of Complicated Molecules" begin
     #Anthracene
     _, Data = OpenSMILES.ParseSMILES("C1=CC=C2C=C3C=CC=CC3=CC2=C1")


### PR DESCRIPTION
There's a fair amount of work that would be needed to provide full support for chiral SMILES, but not throwing an error is at least a start.

See the spec: http://opensmiles.org/opensmiles.html#chirality
