### PR TITLE
Improve Bracket parsing and full chirality parsing

### DIFF
--- a/src/Brackets.jl
+++ b/src/Brackets.jl
@@ -7,76 +7,71 @@
 end
 
 struct BracketParseException <: Exception
+    msg::String
     bracketcontents::String
-    charloc::Int64
+    charloc::Int
 end
-Base.showerror(io::IO, e::BracketParseException) = print(io, "Failed to parse bracket(\"[$(e.bracketcontents)]\") on character ", e.charloc, "!")
+Base.showerror(io::IO, e::BracketParseException) = print(io, "Failed to parse bracket(\"[$(e.bracketcontents)]\") on character ", e.charloc, "!\n", e.msg)
 
-function ParseBracket(S)
-    Sorig = S
-    origlen = curlen = lastlen = length(S)
+function ParseBracket(s::AbstractString)
+    len = length(s)
 
     state = ISOTOPE
     symbol, isotope, aromatic, ringID, hydrogens, charge = nothing, nothing, false, [], 0, 0
 
-    while curlen > 0
-        cursor = S[1]
+    idx = 1
+    while idx <= len
+        cursor = s[idx]
         #Handle isotope, explicit hydrogen multiplicity
-        if isdigit( cursor )
+        if isdigit(cursor)
             if state == ISOTOPE
-                isotope, S = ReadNextNumeric( S )
+                isotope, idx = tryparseint16(s, idx)
                 state = SYMBOL
             elseif state == MULTIPLICITY
-                hydrogens, S = ReadNextNumeric( S )
+                hydrogens, idx = tryparseint16(s, idx)
                 state = CHARGE
             else
-                @warn("Invalid SMILES. Charge must be denoted with +/-.")
+               throw(BracketParseException("Invalid SMILES. Charge must be denoted with +/-.", s, idx))
             end
         #Handle Element symbol parsing
-        elseif isletter( cursor )
-            if ( state == SYMBOL ) || (state == ISOTOPE)
-                if isa( symbol, Nothing )
-                    symbollist = isuppercase( cursor ) ? bracket : bracket_aromatic
-                    aromatic = islowercase( cursor )
-                    symbol, S = ReadNextElement( S, symbollist )
+        elseif isletter(cursor)
+            if state == SYMBOL || state == ISOTOPE
+                if isa(symbol, Nothing)
+                    symbollist = isuppercase(cursor) ? bracket : bracket_aromatic
+                    aromatic = islowercase(cursor)
+                    symbol, idx = tryparseelement(s, idx, symbollist)
                     if isa(symbol, Nothing)
-                        @warn("Invalid SMILES. Unrecognized chemical symbol.")
+                        throw(BracketParseException("Invalid SMILES. Unrecognized chemical symbol.", s, idx))
                     end
-                elseif S[1] == 'H'
+                elseif cursor == 'H'
                     state = MULTIPLICITY
                     hydrogens = 1
-                    S = S[2:end]
+                    idx = nextind(s, idx)
                 else
-                    @warn("Invalid SMILES. Bracket should contain one element (with or without Hydrogen).")
+                    throw(BracketParseException("Invalid SMILES. Bracket should contain one element (with or without Hydrogen).", s, idx))
                 end
             else
-                @warn("Invalid SMILES. Bracket should contain one element.")
+                throw(BracketParseException("Invalid SMILES. Bracket should contain one element.", s, idx))
             end
         #Handle charge
         elseif ispm(cursor)
-            if ( state == CHARGE ) || ( state == MULTIPLICITY ) || ( state == SYMBOL ) || ( state == ISOTOPE )
-                charge, S = ReadNextCharge( S )
+            if state == CHARGE || state == MULTIPLICITY || state == SYMBOL || state == ISOTOPE
+                charge, idx = tryparsecharge(s, idx)
                 state = SYMBOL
             else
-                @warn("Invalid SMILES. Charge should follow element symbol.")
+                throw(BracketParseException("Invalid SMILES. Charge should follow element symbol.", s, idx))
             end
         #Handle operators
         elseif isspecialoperator(cursor)
-            @warn("Invalid SMILES. Special operators(" * join(specialoperators, ",") * ") should not be contained in a bracket.")
+            throw(BracketParseException("Invalid SMILES. Special operators (" * join(specialoperators, ",") * ") should not be contained in a bracket.", s, idx))
         elseif isbondoperator(cursor)
             if cursor == '@'
                 @warn("Chirality is not yet supported, ignoring @ operator", maxlog=1)
-                S = S[2:end]
+                _, idx = tryparsechirality(s, idx)
             else
-                @warn("Invalid SMILES. Bond operators(" * join(bondoperators, ",") * ") should not be contained in a bracket.")
+                throw(BracketParseException("Invalid SMILES. Bond operators(" * join(setdiff(bondoperators, '@'), ",") * ") should not be contained in a bracket.", s, idx))
             end
         end
-        #Ensure we don't get stuck in an infinite loop
-        curlen = length( S )
-        if lastlen == curlen
-            throw(BracketParseException( Sorig, (origlen - curlen + 1) ))
-        end
-        lastlen = curlen
     end
     return Element( symbol, isotope, aromatic, ringID, hydrogens, 0, charge )
 end

--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -4,7 +4,8 @@ const operators = [ specialoperators;  bondoperators ]
 
 const bonds = Dict( '-' => 1, '\\' => 1, '/' => 1, '=' => 2, '#' => 3, '\$' => 4 )
 const valence = Dict( "B" => 3, "C" => 4, "N" => 3, "O" => 2, "P" => 3,
-                      "S" => 2, "F" => 1, "Cl" => 1, "Br" => 1, "I" => 1 )
+                      "S" => 2, "F" => 1, "Cl" => 1, "Br" => 1, "I" => 1,
+                      "H" => 1, "Po" => 4, "As" => 5, "Co" => 6)
 
 const aliphatics  = ["B", "C", "N", "O", "S", "P", "F", "Cl", "Br", "I"]
 const aromatics   = ["b", "c", "n", "o", "s", "p"]
@@ -23,10 +24,10 @@ const bracket = [ "H", "He" ,"Li", "Be", "B", "C", "N", "O", "F", "Ne", "Na",
 
 const bracket_aromatic = ["b", "c", "n", "o", "p", "s", "se", "as"]
 
-isoperator(x) = x ∈ operators
-isbondoperator(x) = x ∈ bondoperators
-isspecialoperator(x) = x ∈ specialoperators
-ispm(x) = x ∈ ('+', '-')
+isoperator(x::AbstractChar) = x ∈ operators
+isbondoperator(x::AbstractChar) = x ∈ bondoperators
+isspecialoperator(x::AbstractChar) = x ∈ specialoperators
+ispm(x::AbstractChar) = x ∈ ('+', '-')
 FindNumerics( S::Vector{Char} ) = findall( isnumeric.( S ) )
 FindPMs( S::Vector{Char} ) = findall( ispm.( S ) )
 

--- a/src/ReadFns.jl
+++ b/src/ReadFns.jl
@@ -25,6 +25,24 @@ function ReadNextElement( S::String , List::Array{ String, 1 } )
     return NextElement, S
 end
 
+function tryparseelement(s::AbstractString, idx::Int, elements)
+    len = length(s)
+    idx > len && return nothing, idx
+    c = s[idx]
+    isletter(c) || return nothing, idx
+    idxnext = nextind(s, idx)
+    cnext = idxnext <= len ? s[idxnext] : '1'
+    if islowercase(cnext)
+        # Try a 2-letter element
+        element = c*cnext
+        element ∈ elements && return element, nextind(s, idxnext)
+    end
+    # Try a 1-letter element
+    element = string(c)
+    element ∈ elements && return element, idxnext
+    return nothing, idx
+end
+
 #Fn for parsing the inside of a bracket...
 function ReadNextNumeric(S::String)
     len = length(S)
@@ -43,6 +61,17 @@ function ReadNextNumeric(S::String)
     return isotope, S
 end
 
+function tryparseint16(s::AbstractString, idx::Int)
+    len = length(s)
+    lastidx = prevind(s, idx)
+    while lastidx < len
+        i = nextind(s, lastidx)
+        isdigit(s[i]) || break
+        lastidx = i
+    end
+    return lastidx >= idx ? (parse(Int16, SubString(s, idx, lastidx)), nextind(s, lastidx)) : (nothing, idx)
+end
+
 function ReadNextCharge(S::String)
     len = length(S)
     charge = nothing
@@ -59,4 +88,41 @@ function ReadNextCharge(S::String)
         end
     end
     return charge, ""
+end
+
+function tryparsecharge(s::AbstractString, idx::Int)
+    len = length(s)
+    idx > len && return nothing, idx
+    c = s[idx]
+    ispm(c) || return nothing, idx
+    sgn = c == '+' ? 1 : -1
+    idxnext = nextind(s, idx)
+    count = 1
+    while idxnext <= len
+        cnext = s[idxnext]
+        if cnext == c
+            count += 1
+            @warn("++ and -- are deprecated in the OpenSMILES specification, please use + or - followed by multiplicity.", maxlog=1)
+            idxnext = nextind(s, idxnext)
+        elseif ispm(cnext)
+            error("+- and -+ are not allowed for charge in SMILES")
+        elseif isdigit(cnext)
+            count == 1 || error("cannot use ++ or -- in charge specification followed by multiplicity")
+            break
+        else
+            return sgn*count, idxnext
+        end
+    end
+    idxnext > len && return sgn*count, idxnext
+    mult, idxnext = tryparseint16(s, idxnext)
+    mult === nothing && return sgn, idxnext
+    @assert count == 1
+    return sgn*mult, idxnext
+end
+
+function tryparsechirality(s::AbstractString, idx::Int)
+    m = match(r"(@TH[12]|@AL[12]|@SP[1-3]|@TB\d\d?|@OH\d\d?|@@?)", s, idx)
+    (m === nothing || m.offset > idx) && return nothing, idx
+    chirality = m.captures[1]::AbstractString
+    return chirality, m.offset + lastindex(chirality)
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -7,12 +7,10 @@ function countitems(x)
 end
 
 function EmpiricalFormula(data::Array{Element, 1} )
-    Hydrogens = sum( H.( data ) )
     countem = Dict(countitems( abbreviation.( data ) ))
-    if "H" in keys( countem )
-        countem["H"] += Hydrogens
-    else
-        countem["H"] = Hydrogens
+    nhydrogens = sum( H.( data ) )
+    if nhydrogens > 0
+        countem["H"] = get(countem, "H", 0) + nhydrogens
     end
     sortem = sort( collect( keys( countem ) ) )
     return join([ (countem[ele] == 1) ? ele : ele * string( countem[ele] ) for ele in sortem])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,11 +58,34 @@ end
 
 @testset "Chirality" begin
     # Chirality is not fully supported, but we shouldn't error
-    G1, Data = OpenSMILES.ParseSMILES("N[C@](Br)(O)C")
-    @test OpenSMILES.EmpiricalFormula( Data ) == "BrC2H6NO"
-    G2, Data = OpenSMILES.ParseSMILES("N[C@@](Br)(C)O")
-    @test OpenSMILES.EmpiricalFormula( Data ) == "BrC2H6NO"
-    @test G1 == G2
+    # Tetrahedral
+    for smiles in ("N[C@](Br)(O)C", "N[C@TH1](Br)(O)C", "N[C@@](Br)(O)C", "N[C@TH2](Br)(O)C")
+        _, Data = OpenSMILES.ParseSMILES(smiles)
+        @test OpenSMILES.EmpiricalFormula( Data ) == "BrC2H6NO"
+    end
+    # Allenal
+    for smiles in ("NC(Br)=[C@]=C(O)C", "NC(Br)=[C@AL1]=C(O)C", "NC(Br)=[C@@]=C(O)C", "NC(Br)=[C@AL2]=C(O)C")
+        _, Data = OpenSMILES.ParseSMILES(smiles)
+        @test OpenSMILES.EmpiricalFormula( Data ) == "BrC4H6NO"
+    end
+    # Square-planar
+    for smiles in ("F[Po@SP1](Cl)(Br)I", "F[Po@SP2](Cl)(Br)I", "F[Po@SP3](Cl)(Br)I")
+        _, Data = OpenSMILES.ParseSMILES(smiles)
+        @test OpenSMILES.EmpiricalFormula( Data ) == "BrClFIPo"
+    end
+    # Trigonal-bipyramidal
+    for smiles in ("S[As@TB1](F)(Cl)(Br)N", "S[As@TB2](Br)(Cl)(F)N", "S[As@TB5](F)(N)(Cl)Br", "F[As@TB10](S)(Cl)(N)Br",
+                   "F[As@TB15](Cl)(S)(Br)N", "Br[As@TB20](Cl)(S)(F)N")
+        _, Data = OpenSMILES.ParseSMILES(smiles)
+        @test OpenSMILES.EmpiricalFormula( Data ) == "AsBrClFH3NS"
+    end
+    # Octahedral
+    for smiles in ("C[Co@](F)(Cl)(Br)(I)S", "F[Co@@](S)(I)(C)(Cl)Br", "S[Co@OH5](F)(I)(Cl)(C)Br",
+                   "Br[Co@OH9](C)(S)(Cl)(F)I", "Br[Co@OH12](Cl)(I)(F)(S)C", "Cl[Co@OH15](C)(Br)(F)(I)S",
+                   "Cl[Co@OH19](C)(I)(F)(S)Br", "I[Co@OH27](Cl)(Br)(F)(S)C")
+        _, Data = OpenSMILES.ParseSMILES(smiles)
+        @test OpenSMILES.EmpiricalFormula( Data ) == "BrCClCoFH4IS"
+    end
 end
 
 @testset "ParseOpenSMILES Empirical Formulas of Complicated Molecules" begin


### PR DESCRIPTION
This also corrects empirical-formula generation to avoid printing "H0"
when there are no hydrogens.

This doesn't support actual chirality any better than it did before, but it recognizes and parses all the chirality designations in the standard.