### PR TITLE
Finish transition to index-based parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Build Status](https://api.cirrus-ci.com/github/caseykneale/OpenSMILES.jl.svg)](https://cirrus-ci.com/github/caseykneale/OpenSMILES.jl)
 
 
-This is a SMILES parser in Julia following the OpenSMILES format (to the best of my ability). Theres probably bugs, this isn't inventive its just a parser that turns SMILES into a weighted LightGraphs graph. Contributions welcome!
+This is a SMILES parser in Julia that aims to follow the [OpenSMILES format](http://opensmiles.org/opensmiles.html) (to the best of my ability). Theres probably bugs, this isn't inventive its just a parser that turns SMILES into a weighted LightGraphs graph. Contributions welcome!
 
 # Examples
 

--- a/src/OpenSMILES.jl
+++ b/src/OpenSMILES.jl
@@ -20,4 +20,5 @@ module OpenSMILES
     include("Utils.jl")
     export WeightedToSimple, countitems
 
+    include("deprecations.jl")
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,23 @@
+if Base.VERSION >= v"1.6.0-DEV.843"
+    depwarn(msg, funcsym) = Base.depwarn(msg, funcsym; force=true)
+else
+    depwarn(msg, funcsym) = Base.depwarn(msg, funcsym)
+end
+
+function ReadNextElement( S::String , List::Array{ String, 1 } )
+    depwarn("`ReadNextElement(s, elements)` is deprecated, please use `tryparseelement(s, idx, elements)` instead.", :ReadNextElement)
+    symbol, idxnext = tryparseelement(S, 1, List)
+    return symbol, S[idxnext:end]
+end
+
+function ReadNextNumeric( S::String)
+    depwarn("`ReadNextNumeric(s)` is deprecated, please use `tryparseint16(s, idx)` instead.", :ReadNextNumeric)
+    i, idxnext = tryparseint16(S, 1)
+    return i, S[idxnext:end]
+end
+
+function ReadNextCharge( S::String)
+    depwarn("`ReadNextCharge(s)` is deprecated, please use `tryparsecharge(s, idx)` instead.", :ReadNextCharge)
+    c, idxnext = tryparsecharge(S, 1)
+    return c, S[idxnext:end]
+end


### PR DESCRIPTION
This finishes the path begun in #9, switching to a non-copying parse mode for `ParseBracket` (which was done in #9) and `ParseSMILES` (this PR). A nice result is that parsing is about 3x faster than before I submitted my first OpenSMILES PR:

On  eeab8bab186902b36f61ef10476a612f1ee1ac60:
```julia
julia> @btime OpenSMILES.ParseSMILES("CCN(CC)C(=O)C1CN(C2CC3=CNC4=CC=CC(=C34)C2=C1)C");
  162.544 μs (2097 allocations: 196.23 KiB)
```

This PR:
```julia
julia> @btime OpenSMILES.ParseSMILES("CCN(CC)C(=O)C1CN(C2CC3=CNC4=CC=CC(=C34)C2=C1)C");
  50.941 μs (1273 allocations: 155.78 KiB)
```

Both were run on Julia 1.6 together with https://github.com/JuliaLang/julia/pull/38446. Essentially all the remaining runtime is due to calling `add_vertex!` in `ParseSMILES`, so any further performance improvements will have to come from bulk-allocating the graph (we could probably store the data we need while building it separately, and then create the whole graph at the end).

This also fixes a bug in 2-digit ring identifiers.

Note that I've added deprecations for `ReadNextElement`, `ReadNextNumeric`, and `ReadNextCharge`, as well as docstrings for their replacements.