### PR TITLE
Add `instantiate_hydrogens`

### DIFF
--- a/src/Elements.jl
+++ b/src/Elements.jl
@@ -49,12 +49,16 @@ function Element(symbol::String)
     end
 end
 
+Element(e::Element) = Element(e.symbol, e.isotope, e.aromatic, copy(e.ringID), e.explicithydrogens, e.implicithydrogens, e.charge)
+
 function Base.:(==)(a::Element, b::Element)
     return all( [ a.symbol == b.symbol, a.isotope == b.isotope,
                 a.aromatic == b.aromatic, a.ringID == b.ringID,
                 a.explicithydrogens == b.explicithydrogens,
                 a.charge == b.charge])
 end
+
+Base.copy(e::Element) = Element(e)
 
 #immutable struct to hold elemental information - less memory then "Element"
 struct GraphElement

--- a/src/OpenSMILES.jl
+++ b/src/OpenSMILES.jl
@@ -6,7 +6,7 @@ module OpenSMILES
             aliphatics, aromatics, bracket, bracket_aromatic, isoperator,
             isbondoperator, isspecialoperator, ispm, FindNumerics, FindPMs,
             Element, GraphElement, abbreviation, implicitH, explicitH, H,
-            charge, isotope, ==
+            charge, isotope, ==, instantiate_hydrogens
 
     include("ReadFns.jl")
     export ReadNextElement, ReadNextNumeric, ReadNextCharge

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -8,10 +8,33 @@ end
 
 function EmpiricalFormula(data::Array{Element, 1} )
     countem = Dict(countitems( abbreviation.( data ) ))
-    nhydrogens = sum( H.( data ) )
+    nhydrogens = sum(H, data)
     if nhydrogens > 0
         countem["H"] = get(countem, "H", 0) + nhydrogens
     end
     sortem = sort( collect( keys( countem ) ) )
     return join([ (countem[ele] == 1) ? ele : ele * string( countem[ele] ) for ele in sortem])
+end
+
+"""
+    gH, atomnodesH = instantiate_hydrogens(g, atomnodes)
+
+Given a molecule, where `g` is the connectivity graph and `atomnodes` contains additional
+information about the vertices, return a new representation `gH, atomnodesH` where all hydrogens
+in `g`, `atomnodes` have been instantiated as full nodes in `gH, atomnodesH`.
+"""
+function instantiate_hydrogens(g::AbstractGraph, atomnodes::AbstractVector{Element})
+    gH, atomnodesH = copy(g), [copy(atom) for atom in atomnodes]
+    nhydrogens = sum(H, atomnodes)
+    nhydrogens == 0 && return gH, atomnodesH
+    lastH = nv(g)
+    add_vertices!(gH, nhydrogens)
+    for (i, atom) in enumerate(atomnodesH)
+        for _ = 1:H(atom)
+            add_edge!(gH, i, lastH += 1)
+        end
+        atom.explicithydrogens = atom.implicithydrogens = 0
+    end
+    append!(atomnodesH, [Element("H") for _ in 1:nhydrogens])
+    return gH, atomnodesH
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,3 +132,25 @@ end
     _, Data = OpenSMILES.ParseSMILES("O=C(O)[CH]1N=C(SC1)c2sc3cc(O)ccc3n2")
     @test OpenSMILES.EmpiricalFormula( Data ) == "C11H8N2O3S2"
 end
+
+@testset "instantiate_hydrogens" begin
+    g, atomnodes = OpenSMILES.ParseSMILES("O")
+    gH, atomnodesH = instantiate_hydrogens(g, atomnodes)
+    # Ensure the input is not modified
+    @test nv(g) == 1
+    @test length(atomnodes) == 1 && atomnodes[1].symbol == "O"
+    @test OpenSMILES.EmpiricalFormula(atomnodes) == "H2O"
+    # Check the instantiated version
+    @test nv(gH) == 3
+    @test length(atomnodesH) == 3
+    @test atomnodesH[1].symbol == "O"
+    @test atomnodesH[2].symbol == "H"
+    @test atomnodesH[3].symbol == "H"
+    @test has_edge(gH, 1, 2) && has_edge(gH, 1, 3) && !has_edge(gH, 2, 3)
+    @test OpenSMILES.EmpiricalFormula(atomnodesH) == "H2O"
+
+    g, atomnodes = OpenSMILES.ParseSMILES("[H]O[H]")
+    gH, atomnodesH = instantiate_hydrogens(g, atomnodes)
+    @test g == gH && atomnodes == atomnodesH
+    @test g !== gH && atomnodes !== atomnodesH    # it's a copy, not the same object
+end


### PR DESCRIPTION
This provides a simple utility that converts explicit/implicit
hydrogens into full graph nodes, just as for all other elements.
I'm using this for sidechain analysis of ring systems,
and having all atoms be nodes ensures that one can use subgraph
methods to classify the sidechains.